### PR TITLE
Added temporary debug page to better understand context when hosted on ReadTheDocs

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,0 +1,30 @@
+---
+title: Debug
+layout: page
+---
+
+## Debug
+
+### Readthedocs
+
+*[Reference](https://docs.readthedocs.io/en/stable/development/design/theme-context.html#context-injected)*
+
+{{ readthedocs }}
+
+### Mkdocs
+
+#### Base URL
+
+base_url: `{{ base_url }}`
+
+#### Environment
+
+{{ context(environment) | pretty }}
+
+#### Global Variables
+
+{{ context(extra) | pretty }}
+
+#### Config
+
+{{ context(config) | pretty }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,8 @@ nav:
     - Python Interface: extend/python.md
     - Plugins: extend/plugins.md
     - Third-Party: extend/integrate.md
+  - Debug:
+    - Debug: debug.md
 
 # Plugins
 plugins:


### PR DESCRIPTION
@SchrodingersGat I don't know of any other way to debug #2, if we can have a better idea of the context then maybe we can find out some logic to be able to serve images both locally and on ReadTheDocs without any extra document-er effort.