### PR TITLE
adding in F360-InvenTree link

### DIFF
--- a/docs/extend/integrate.md
+++ b/docs/extend/integrate.md
@@ -13,3 +13,8 @@ A list of known third-party InvenTree extensions is provided below. If you have 
 ### PK2InvenTree
 
 [PK2InvenTree](https://github.com/rgilham/PK2InvenTree) is an open-source tool for migrating an existing [PartKeepr](https://github.com/partkeepr/PartKeepr) database to InvenTree.
+
+### F360-InvenTree
+
+[F360-InvenTree](https://github.com/matmair/F360-InvenTree/) is a tool for creating links between Autodesk Fusion 360 components and InvenTree parts.  
+Still under heavy development.


### PR DESCRIPTION
This PR adds a link to F360-InvenTree in the lugin-section of the docs.
I will finish dev on milestone 1.0 soon and make the repo public by then so this will be set to draft till then