### PR TITLE
Fix top margin

### DIFF
--- a/docs/stylesheets/bootstrap.css
+++ b/docs/stylesheets/bootstrap.css
@@ -2583,7 +2583,7 @@ html {
     border: 0;
     border-bottom: 1px solid #e5e5e5;
   }
-  label {
+  label:not(.md-overlay) {
     display: inline-block;
     max-width: 100%;
     margin-bottom: 5px;


### PR DESCRIPTION
Excluded `.md-overlay` class from label CSS

Fixes #144 