### PR TITLE
Bump python version

### DIFF
--- a/.github/workflows/check_config.yaml
+++ b/.github/workflows/check_config.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Run Checks
         run: |
           pip install pyyaml

--- a/docs/start/intro.md
+++ b/docs/start/intro.md
@@ -52,7 +52,7 @@ The InvenTree documentation assumes that the operating system is a debian based 
 InvenTree runs on [Python](https://python.org).
 
 !!! warning "Python Version"
-    InvenTree requrires Python 3.7 (or newer). If your system has an older version of Python installed, you will need to follow the update instructions for your OS.
+    InvenTree requrires Python 3.8 (or newer). If your system has an older version of Python installed, you will need to follow the update instructions for your OS.
 
 ### Invoke
 


### PR DESCRIPTION
This PR bumps the python version in the docs and for the CI.

https://github.com/inventree/InvenTree/pull/2994