### PR TITLE
Improve plugins docs

### DIFF
--- a/docs/extend/how_to_plugin.md
+++ b/docs/extend/how_to_plugin.md
@@ -49,6 +49,10 @@ from plugin.mixins import APICallMixin, SettingsMixin, ScheduleMixin, BarcodeMix
 
 ### Packaging
 
+
+!!! tip "Package-Discovery can be tricky"
+    Most problems with packaging stem from problems with dicovery. [This guide](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#automatic-discovery) by the PyPA contains a lot of information about discovery during packaging. Theses mechanisms generally apply to most discovery processes in InvenTree and the wider Django ecosystem.
+
 The recommended way of distribution is as a [PEP 561](https://peps.python.org/pep-0561/) compliant package. If you can use the official Package Index (PyPi - [official website](https://pypi.org/)) as a registry.  
 Please follow PyPAs official [packaging guide](https://packaging.python.org/en/latest/tutorials/packaging-projects/) to ensure your package installs correctly suing InvenTrees install mechanisms.
 

--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -8,7 +8,7 @@ The InvenTree server code supports an extensible plugin architecture, allowing c
 
 Plugins can be added from multiple sources:
 
-- Plugins can be installed via PIP (python package manager)
+- Plugins can be installed in InvenTrees venv via PIP (python package manager)
 - Custom plugins should be placed in the directory `./InvenTree/plugins`.
 - InvenTree built-in plugins are located in the directory `./InvenTree/plugin/builtin`.  
 

--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -91,7 +91,7 @@ The configuration entries must be enabled via the [InvenTree admin interface](..
 
 ### Plugin Mixins
 
-Common use cases are covered by pre-supplied modules in the form of *mixins* (similar to how [django](https://docs.djangoproject.com/en/stable/topics/class-based-views/mixins/) does it). Each mixin enables the integration into a specific area of InvenTree. Sometimes it also enhances the plugin with helper functions to supply often used functions out-of-the-box.
+Common use cases are covered by pre-supplied modules in the form of *mixins* (similar to how [Django](https://docs.djangoproject.com/en/stable/topics/class-based-views/mixins/) does it). Each mixin enables the integration into a specific area of InvenTree. Sometimes it also enhances the plugin with helper functions to supply often used functions out-of-the-box.
 
 Supported mixin classes are:
 


### PR DESCRIPTION
Adds
- some context to discovery during packaging
- the info that InvenTrees env must be used for pip installs
and fixes the spelling of Django in one instance
Closes #352