### PR TITLE
Updated requirements, updated mkdocs-material to v0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-macros-plugin>=0.6,<1.0
-mkdocs-material>=8.2,<9.0
-mkdocs-git-revision-date-localized-plugin>=1.0,<2.0
+mkdocs-macros-plugin>=0.7,<1.0
+mkdocs-material>=9.0,<10.0
+mkdocs-git-revision-date-localized-plugin>=1.1,<2.0
 mkdocs-simple-hooks>=0.1,<1.0


### PR DESCRIPTION
Reference: https://github.com/squidfunk/mkdocs-material/releases/tag/9.0.0

Tested locally and looks fine.