### PR TITLE
From 0.12.0 release notes will only be on github

### DIFF
--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -22,10 +22,8 @@ The head of the *master* code branch represents the "latest and greatest" workin
 
 ## Stable Releases
 
-Specific tagged releases are shown below. Click on the release notes for each version to learn more.
-
 !!! info "Release Notes"
-    Starting from v0.7.2, release notes have been migrated to GitHub. Release notes for older versions are available at the links below.
+    Starting from version 0.12.0, release notes are now available only on the [InvenTree GitHub Releases Page](https://github.com/inventree/InvenTree/releases). Release notes for versions prior to 0.12.0 are also tagged below.
 
 ### 0.11.x
 {% with prefix="0.11" %}{% include "release_table.html" %}{% endwith %}
@@ -39,8 +37,12 @@ Specific tagged releases are shown below. Click on the release notes for each ve
 ### 0.8.x
 {% with prefix="0.8" %}{% include "release_table.html" %}{% endwith %}
 
+!!! info "Release Notes"
+    Starting from v0.7.2, release notes have been migrated to GitHub. Release notes for older versions are available at the links below.
+
 ### 0.7.x
 {% with prefix="0.7" %}{% include "release_table.html" %}{% endwith %}
+
 
 ### 0.6.x
 {% with prefix="0.6" %}{% include "release_table.html" %}{% endwith %}


### PR DESCRIPTION
As part of https://github.com/inventree/InvenTree/issues/4623

Reduce the workload on making new releases, by simply linking to the github release page.